### PR TITLE
feat: 중복 제목 검사 로직 변경

### DIFF
--- a/src/main/java/diary/exception/GlobalExceptionHandler.java
+++ b/src/main/java/diary/exception/GlobalExceptionHandler.java
@@ -43,6 +43,6 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.CONFLICT)
     @ResponseBody
     public String handleDataIntegrityViolation(DataIntegrityViolationException e) {
-        return "제목은 중복된 값이 불가능합니다.";
+        return "데이터베이스 무결성 오류가 발생했습니다. 다시 시도해주세요.";
     }
 }

--- a/src/main/java/diary/repository/DiaryRepository.java
+++ b/src/main/java/diary/repository/DiaryRepository.java
@@ -14,6 +14,6 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
     List<DiaryEntity> findTop10ByOrderByIdDesc();
     @Query("SELECT d FROM DiaryEntity d ORDER BY LENGTH(d.content) DESC, d.id DESC")
     List<DiaryEntity> findTop10ByContentLength(PageRequest pageRequest);
-    DiaryEntity findByTitle(String title);
+    boolean existsByTitle(String title);
     List<DiaryEntity> findByCategoryOrderByIdDesc(DiaryEntity.Category category);
 }

--- a/src/main/java/diary/service/DiaryService.java
+++ b/src/main/java/diary/service/DiaryService.java
@@ -21,6 +21,10 @@ public class DiaryService {
     }
 
     public void createDiary(String title, String content, Category category) {
+        if (diaryRepository.existsByTitle(title)) {
+            throw new IllegalArgumentException("제목은 중복된 값이 불가능합니다.");
+        }
+
         if (title.length() > 10) {
             throw new IllegalArgumentException("제목은 10자 이하로 작성해주세요.");
         } else if (content.length() > 30) {


### PR DESCRIPTION
1. 중복 제목 제약 조건을 DB와 서비스에서 Service에서 함께 관리하도록 변경
- 데이터베이스 부담 + Race Condition을 모두 고려한 해결책