### PR TITLE
feat: 카테고리별 조회 요청을 인덱스로 구분, 일기 목록 반환 시 Flux 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 test {

--- a/src/main/java/diary/api/DiaryController.java
+++ b/src/main/java/diary/api/DiaryController.java
@@ -1,7 +1,6 @@
 package diary.api;
 
 import diary.dto.DiaryDetailResponse;
-import diary.dto.DiaryListResponse;
 import diary.dto.DiaryRequest;
 import diary.dto.DiaryResponse;
 import diary.dto.Diary;
@@ -9,9 +8,7 @@ import diary.repository.DiaryEntity;
 import diary.service.DiaryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.ArrayList;
-import java.util.List;
+import reactor.core.publisher.Flux;
 
 @RestController
 public class DiaryController {
@@ -28,58 +25,34 @@ public class DiaryController {
     }
 
     @GetMapping("/api/diary/all")
-    ResponseEntity<DiaryListResponse> get(){
-        List<Diary> diaryList = diaryService.getAllDiary();
-
-        List<DiaryResponse> diaryResponseList = new ArrayList<>();
-        for(Diary diary : diaryList){
-            diaryResponseList.add(new DiaryResponse(diary.id(), diary.title(), diary.category()));
-        }
-
-        return ResponseEntity.ok(new DiaryListResponse(diaryResponseList));
+    Flux<DiaryResponse> getAll() {
+        return diaryService.getAllDiary()
+                .flatMap(diary -> Flux.just(new DiaryResponse(diary.id(), diary.title(), diary.category())));
     }
 
     @GetMapping("/api/diary")
-    ResponseEntity<DiaryListResponse> getRecent(){
-        List<Diary> diaryList = diaryService.getRecentDiary();
-
-        List<DiaryResponse> diaryResponseList = new ArrayList<>();
-        for(Diary diary : diaryList){
-            diaryResponseList.add(new DiaryResponse(diary.id(), diary.title(), diary.category()));
-        }
-
-        return ResponseEntity.ok(new DiaryListResponse(diaryResponseList));
+    Flux<DiaryResponse> getRecent() {
+        return diaryService.getRecentDiary()
+                .flatMap(diary -> Flux.just(new DiaryResponse(diary.id(), diary.title(), diary.category())));
     }
 
     @GetMapping("/api/diary/sorted")
-    ResponseEntity<DiaryListResponse> getSorted(){
-        List<Diary> diaryList = diaryService.getSortedDiary();
+    Flux<DiaryResponse> getSorted() {
+        return diaryService.getSortedDiary()
+                .flatMap(diary -> Flux.just(new DiaryResponse(diary.id(), diary.title(), diary.category())));
+    }
 
-        List<DiaryResponse> diaryResponseList = new ArrayList<>();
-        for (Diary diary : diaryList){
-            diaryResponseList.add(new DiaryResponse(diary.id(), diary.title(), diary.category()));
-        }
-
-        return ResponseEntity.ok(new DiaryListResponse(diaryResponseList));
+    @GetMapping("/api/diary/category/{categoryId}")
+    Flux<DiaryResponse> getCategory(@PathVariable Integer categoryId) {
+        DiaryEntity.Category category = DiaryEntity.Category.values()[categoryId];
+        return diaryService.getDiariesByCategory(category)
+                .flatMap(diary -> Flux.just(new DiaryResponse(diary.id(), diary.title(), diary.category())));
     }
 
     @GetMapping("/api/diary/{id}")
     ResponseEntity<DiaryDetailResponse> getById(@PathVariable Long id) {
         Diary diary = diaryService.getDiaryById(id);
-
         return ResponseEntity.ok(new DiaryDetailResponse(diary.id(), diary.title(), diary.content(), diary.date(), diary.category()));
-    }
-
-    @GetMapping("/api/diary/category/{category}")
-    ResponseEntity<DiaryListResponse> getCategory(@PathVariable DiaryEntity.Category category){
-        List<Diary> diaryList = diaryService.getDiariesByCategory(category);
-
-        List<DiaryResponse> diaryResponseList = new ArrayList<>();
-        for (Diary diary : diaryList){
-            diaryResponseList.add(new DiaryResponse(diary.id(), diary.title(), diary.category()));
-        }
-
-        return ResponseEntity.ok(new DiaryListResponse(diaryResponseList));
     }
 
     @PatchMapping("/api/diary/{id}")

--- a/src/main/java/diary/service/DiaryService.java
+++ b/src/main/java/diary/service/DiaryService.java
@@ -7,9 +7,8 @@ import diary.repository.DiaryEntity.Category;
 import diary.repository.DiaryRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @Component
@@ -43,43 +42,24 @@ public class DiaryService {
         diaryRepository.save(new DiaryEntity(title, content, LocalDateTime.now(), category));
     }
 
-    public ArrayList<Diary> getAllDiary() {
-        final List<DiaryEntity> diaryEntityList = diaryRepository.findAllByOrderByIdDesc();
-        final ArrayList<Diary> diaryList = new ArrayList<>();
-
-        for (DiaryEntity diaryEntity : diaryEntityList) {
-            diaryList.add(
-                    new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory())
-            );
-        }
-
-        return diaryList;
+    public Flux<Diary> getAllDiary() {
+        return Flux.fromIterable(diaryRepository.findAllByOrderByIdDesc())
+                .map(diaryEntity -> new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory()));
     }
 
-    public ArrayList<Diary> getRecentDiary() {
-        List<DiaryEntity> diaryEntityList = diaryRepository.findTop10ByOrderByIdDesc();
-        ArrayList<Diary> diaryList = new ArrayList<>();
-
-        for (DiaryEntity diaryEntity : diaryEntityList) {
-            diaryList.add(
-                    new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory())
-            );
-        }
-
-        return diaryList;
+    public Flux<Diary> getRecentDiary() {
+        return Flux.fromIterable(diaryRepository.findTop10ByOrderByIdDesc())
+                .map(diaryEntity -> new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory()));
     }
 
-    public ArrayList<Diary> getSortedDiary() {
-        List<DiaryEntity> diaryEntityList = diaryRepository.findTop10ByContentLength(PageRequest.of(0, 10));
-        ArrayList<Diary> diaryList = new ArrayList<>();
+    public Flux<Diary> getSortedDiary() {
+        return Flux.fromIterable(diaryRepository.findTop10ByContentLength(PageRequest.of(0, 10)))
+                .map(diaryEntity -> new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory()));
+    }
 
-        for (DiaryEntity diaryEntity : diaryEntityList) {
-            diaryList.add(
-                    new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory())
-            );
-        }
-
-        return diaryList;
+    public Flux<Diary> getDiariesByCategory(Category category) {
+        return Flux.fromIterable(diaryRepository.findByCategoryOrderByIdDesc(category))
+                .map(diaryEntity -> new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory()));
     }
 
     public Diary getDiaryById(Long id) {
@@ -109,18 +89,5 @@ public class DiaryService {
         DiaryEntity diaryEntity = diaryRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("일기를 찾을 수 없습니다. ID: " + id));
         diaryRepository.deleteById(id);
-    }
-
-    public ArrayList<Diary> getDiariesByCategory(Category category) {
-        List<DiaryEntity> diaryEntityList = diaryRepository.findByCategoryOrderByIdDesc(category);
-        ArrayList<Diary> diaryList = new ArrayList<>();
-
-        for (DiaryEntity diaryEntity : diaryEntityList) {
-            diaryList.add(
-                    new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory())
-            );
-        }
-
-        return diaryList;
     }
 }


### PR DESCRIPTION
1. 카테고리별 조회 시, PathVariable에 해당 카테고리의 Enum 인덱스를 넣는 방식으로 변경
2. DiaryListResponse 대신, Flux를 사용하여 비동기적으로 반환 (일기 목록을 조회하는 요청에 대해서만)