### PR TITLE
revert: 2주차 과제 완료 (비동기 처리 롤백)

### DIFF
--- a/src/main/java/diary/api/DiaryController.java
+++ b/src/main/java/diary/api/DiaryController.java
@@ -1,6 +1,7 @@
 package diary.api;
 
 import diary.dto.DiaryDetailResponse;
+import diary.dto.DiaryListResponse;
 import diary.dto.DiaryRequest;
 import diary.dto.DiaryResponse;
 import diary.dto.Diary;
@@ -8,7 +9,8 @@ import diary.repository.DiaryEntity;
 import diary.service.DiaryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Flux;
+import java.util.ArrayList;
+import java.util.List;
 
 @RestController
 public class DiaryController {
@@ -25,34 +27,58 @@ public class DiaryController {
     }
 
     @GetMapping("/api/diary/all")
-    Flux<DiaryResponse> getAll() {
-        return diaryService.getAllDiary()
-                .flatMap(diary -> Flux.just(new DiaryResponse(diary.id(), diary.title(), diary.category())));
+    ResponseEntity<DiaryListResponse> get(){
+        List<Diary> diaryList = diaryService.getAllDiary();
+
+        List<DiaryResponse> diaryResponseList = new ArrayList<>();
+        for(Diary diary : diaryList){
+            diaryResponseList.add(new DiaryResponse(diary.id(), diary.title(), diary.category()));
+        }
+
+        return ResponseEntity.ok(new DiaryListResponse(diaryResponseList));
     }
 
     @GetMapping("/api/diary")
-    Flux<DiaryResponse> getRecent() {
-        return diaryService.getRecentDiary()
-                .flatMap(diary -> Flux.just(new DiaryResponse(diary.id(), diary.title(), diary.category())));
+    ResponseEntity<DiaryListResponse> getRecent(){
+        List<Diary> diaryList = diaryService.getRecentDiary();
+
+        List<DiaryResponse> diaryResponseList = new ArrayList<>();
+        for(Diary diary : diaryList){
+            diaryResponseList.add(new DiaryResponse(diary.id(), diary.title(), diary.category()));
+        }
+
+        return ResponseEntity.ok(new DiaryListResponse(diaryResponseList));
     }
 
     @GetMapping("/api/diary/sorted")
-    Flux<DiaryResponse> getSorted() {
-        return diaryService.getSortedDiary()
-                .flatMap(diary -> Flux.just(new DiaryResponse(diary.id(), diary.title(), diary.category())));
-    }
+    ResponseEntity<DiaryListResponse> getSorted(){
+        List<Diary> diaryList = diaryService.getSortedDiary();
 
-    @GetMapping("/api/diary/category/{categoryId}")
-    Flux<DiaryResponse> getCategory(@PathVariable Integer categoryId) {
-        DiaryEntity.Category category = DiaryEntity.Category.values()[categoryId];
-        return diaryService.getDiariesByCategory(category)
-                .flatMap(diary -> Flux.just(new DiaryResponse(diary.id(), diary.title(), diary.category())));
+        List<DiaryResponse> diaryResponseList = new ArrayList<>();
+        for (Diary diary : diaryList){
+            diaryResponseList.add(new DiaryResponse(diary.id(), diary.title(), diary.category()));
+        }
+
+        return ResponseEntity.ok(new DiaryListResponse(diaryResponseList));
     }
 
     @GetMapping("/api/diary/{id}")
     ResponseEntity<DiaryDetailResponse> getById(@PathVariable Long id) {
         Diary diary = diaryService.getDiaryById(id);
+
         return ResponseEntity.ok(new DiaryDetailResponse(diary.id(), diary.title(), diary.content(), diary.date(), diary.category()));
+    }
+
+    @GetMapping("/api/diary/category/{category}")
+    ResponseEntity<DiaryListResponse> getCategory(@PathVariable DiaryEntity.Category category){
+        List<Diary> diaryList = diaryService.getDiariesByCategory(category);
+
+        List<DiaryResponse> diaryResponseList = new ArrayList<>();
+        for (Diary diary : diaryList){
+            diaryResponseList.add(new DiaryResponse(diary.id(), diary.title(), diary.category()));
+        }
+
+        return ResponseEntity.ok(new DiaryListResponse(diaryResponseList));
     }
 
     @PatchMapping("/api/diary/{id}")

--- a/src/main/java/diary/dto/DiaryListResponse.java
+++ b/src/main/java/diary/dto/DiaryListResponse.java
@@ -1,0 +1,6 @@
+package diary.dto;
+
+import java.util.List;
+
+public record DiaryListResponse(List<DiaryResponse> diaryList) {
+}

--- a/src/main/java/diary/repository/DiaryRepository.java
+++ b/src/main/java/diary/repository/DiaryRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/diary/service/DiaryService.java
+++ b/src/main/java/diary/service/DiaryService.java
@@ -7,8 +7,9 @@ import diary.repository.DiaryEntity.Category;
 import diary.repository.DiaryRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Flux;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Component
@@ -42,24 +43,43 @@ public class DiaryService {
         diaryRepository.save(new DiaryEntity(title, content, LocalDateTime.now(), category));
     }
 
-    public Flux<Diary> getAllDiary() {
-        return Flux.fromIterable(diaryRepository.findAllByOrderByIdDesc())
-                .map(diaryEntity -> new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory()));
+    public ArrayList<Diary> getAllDiary() {
+        final List<DiaryEntity> diaryEntityList = diaryRepository.findAllByOrderByIdDesc();
+        final ArrayList<Diary> diaryList = new ArrayList<>();
+
+        for (DiaryEntity diaryEntity : diaryEntityList) {
+            diaryList.add(
+                    new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory())
+            );
+        }
+
+        return diaryList;
     }
 
-    public Flux<Diary> getRecentDiary() {
-        return Flux.fromIterable(diaryRepository.findTop10ByOrderByIdDesc())
-                .map(diaryEntity -> new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory()));
+    public ArrayList<Diary> getRecentDiary() {
+        List<DiaryEntity> diaryEntityList = diaryRepository.findTop10ByOrderByIdDesc();
+        ArrayList<Diary> diaryList = new ArrayList<>();
+
+        for (DiaryEntity diaryEntity : diaryEntityList) {
+            diaryList.add(
+                    new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory())
+            );
+        }
+
+        return diaryList;
     }
 
-    public Flux<Diary> getSortedDiary() {
-        return Flux.fromIterable(diaryRepository.findTop10ByContentLength(PageRequest.of(0, 10)))
-                .map(diaryEntity -> new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory()));
-    }
+    public ArrayList<Diary> getSortedDiary() {
+        List<DiaryEntity> diaryEntityList = diaryRepository.findTop10ByContentLength(PageRequest.of(0, 10));
+        ArrayList<Diary> diaryList = new ArrayList<>();
 
-    public Flux<Diary> getDiariesByCategory(Category category) {
-        return Flux.fromIterable(diaryRepository.findByCategoryOrderByIdDesc(category))
-                .map(diaryEntity -> new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory()));
+        for (DiaryEntity diaryEntity : diaryEntityList) {
+            diaryList.add(
+                    new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory())
+            );
+        }
+
+        return diaryList;
     }
 
     public Diary getDiaryById(Long id) {
@@ -89,5 +109,18 @@ public class DiaryService {
         DiaryEntity diaryEntity = diaryRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("일기를 찾을 수 없습니다. ID: " + id));
         diaryRepository.deleteById(id);
+    }
+
+    public ArrayList<Diary> getDiariesByCategory(Category category) {
+        List<DiaryEntity> diaryEntityList = diaryRepository.findByCategoryOrderByIdDesc(category);
+        ArrayList<Diary> diaryList = new ArrayList<>();
+
+        for (DiaryEntity diaryEntity : diaryEntityList) {
+            diaryList.add(
+                    new Diary(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDate(), diaryEntity.getCategory())
+            );
+        }
+
+        return diaryList;
     }
 }


### PR DESCRIPTION
### ✅  **Controller, Service 검증 분리**

### ▶️ **기본 검증**

```java
@ExceptionHandler(HttpMessageNotReadableException.class)
@ResponseStatus(HttpStatus.BAD_REQUEST)
@ResponseBody
public String handleDefaultException(HttpMessageNotReadableException e) {
	return "올바르지 않은 값이 전달되었습니다. 요청 형식을 확인해주세요.";
}
```

• 타입 에러 등, 요청 body를 파싱할 수 없는 에러의 경우 `HttpMessageNotReadableException`를 발생시키기 때문에, `GlobalExceptionHandler` 측에서 해당 Exception을 처리하도록 하였다.

### ▶️ **Controller 검증**

```java
public record DiaryRequest(String title, String content, DiaryEntity.Category category) {
    public void validate() {
        if (title == null) {
            throw new IllegalArgumentException("제목을 입력해주세요.");
        }
        if (content == null) {
            throw new IllegalArgumentException("내용을 입력해주세요.");
        }
        if (category == null) {
            throw new IllegalArgumentException("카테고리를 입력해주세요.");
        }
    }
}
```

- 팀 회의 결과, 제목과 내용이 빈 값인 경우는 허용하도록 결정하였다.
- 하지만 필드 자체가 포함되어 있지 않은 경우는 검증해줘야 한다고 판단했고, Controller에서 POST, PATCH 시 `validate()` 함수를 호출하도록 했다.

### ▶️ **Service 검증**

```java
public void createDiary(String title, String content, Category category) {
        if (diaryRepository.existsByTitle(title)) {
            throw new IllegalArgumentException("제목은 중복된 값이 불가능합니다.");
        }

        if (title.length() > 10) {
            throw new IllegalArgumentException("제목은 10자 이하로 작성해주세요.");
        } else if (content.length() > 30) {
            throw new IllegalArgumentException("내용은 30자 이하로 작성해주세요.");
        }

        DiaryEntity lastDiary = diaryRepository.findTopByOrderByIdDesc().orElse(null);
        if (lastDiary != null) {
            LocalDateTime lastDate = lastDiary.getDate();
            LocalDateTime now = LocalDateTime.now();
            if (now.isBefore(lastDate.plusMinutes(5))) {
                throw new RateLimitException("5분에 한 번 일기를 작성할 수 있습니다.");
            }
        }

        diaryRepository.save(new DiaryEntity(title, content, LocalDateTime.now(), category));
    }
```

- 제목 중복 값, 글자 수 제한, 작성 주기 제한 등은 비즈니스 로직과 관련된 검증이라고 판단했다.
- 따라서 Service의 `createDiary` 내부에서 검증하는 것으로 구현하였다.

### ✅  **Race Condition 고려 (제목 중복 값 검증)**

- 단순히 Service에서 제목의 유일성을 검증할 경우, Race Condition이 발생할 수 있다는 우려를 하였다.
- 구체적으로, 동시에 두 명의 사용자가 같은 제목의 일기를 삽입하는 경우, (하나의 요청이 Service 검증을 통과한 후 DB에 삽입되기 전, 또다른 요청이 Service 검증을 요청하면 해당 요청도 검증 통과) 중복 값이 저장될 수 있다고 예상했다.
- 이에 따라 Entity의 title 필드를 unique로 만들어주어, 기본적으로 Service에서 검증을 진행하되, Race Condition으로 인해 중복 값이 저장되려고 할 경우 `DataIntegrityViolationException` 오류를 일으키도록 구현하였다.

```java
@Entity
public class DiaryEntity {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    public Long id;

    @Column(unique = true)
    public String title;

    public String content;
    public LocalDateTime date;

    @Enumerated(EnumType.STRING)
    public Category category;

    public DiaryEntity() {}

    public DiaryEntity(String title, String content, LocalDateTime date, Category category) {
        this.title = title;
        this.content = content;
        this.date = date;
        this.category = category;
    }

    public enum Category {
        DAILY, FOOD, EXERCISE, WORK, STUDY, OTHER
    }

    public long getId() {
        return id;
    }

    public String getTitle() {
        return title;
    }

    public String getContent() {
        return content;
    }

    public LocalDateTime getDate() {
        return date;
    }

    public Category getCategory() {
        return category;
    }

    public void setTitle(String title) {
        this.title = title;
    }

    public void setContent(String content) {
        this.content = content;
    }

    public void setCategory(Category category) {
        this.category = category;
    }
}
```

```java
@ExceptionHandler(DataIntegrityViolationException.class)
    @ResponseStatus(HttpStatus.CONFLICT)
    @ResponseBody
    public String handleDataIntegrityViolation(DataIntegrityViolationException e) {
        return "데이터베이스 무결성 오류가 발생했습니다. 다시 시도해주세요.";
    }
   
```

- 기본적으로 Service에서 검증을 진행한 이유는, 검증 로직이 DB 의존적이지 않도록 유지하고, DB 부하(롤백)을 줄이기 위해서!
- 한 명의 사용자가 하나의 일기 목록을 관리하는 방식이라면 의미 없는 고민이라고 생각했지만, 기획에 명시된 부분은 아니기에 여러 사용자가 하나의 일기 목록에 접근하는 경우를 고려하였다.

### ✅  **비동기 구현 시도**

- 만약 일기의 수가 많다면, 일기 목록을 DB에서 읽고 반환해주는 과정을 비동기 처리해줘야 하지 않을까? 라는 생각이 들었다.
- Spring 생태계에 대한 스스로의 이해 정도가 크지 않아서, 우선 주먹구구식으로 Flux와 ReactiveCrudRepository로 구현해보려고 하였다.
- 문제는, 일기 목록 조회 등의 작업에서만 비동기 처리를 해주는 것이 의도했던 방향이었는데, 위와 같이 진행할 경우 프로젝트의 전체적인 흐름을 비동기적으로 가져가야 할 것 같다는 생각이 들었다.
- 이 부분은 파트장님께 개인적으로 질문을 드린 후, 보다 더 고민한 후 다시 구현해보고 싶다!